### PR TITLE
Added basic error handling for no-text situations.

### DIFF
--- a/lib/status-wordcount-view.coffee
+++ b/lib/status-wordcount-view.coffee
@@ -9,9 +9,12 @@ class StatusWordcountView extends View
     atom.workspaceView.command "status-wordcount:toggle", => @toggle()
 
   updateWordCount: =>
-    editor = atom.workspaceView.getActivePaneItem()
-    count = editor.getText().match(/\S+/g).length
-    @text("#{count} words").show()
+    try
+        editor = atom.workspaceView.getActivePaneItem()
+        count = editor.getText().match(/\S+/g).length
+        @text("#{count} words").show()
+    catch
+        @text("read-only").show()
 
   serialize: ->
 


### PR DESCRIPTION
Prevents crashing when you can't getText() on a pane.
